### PR TITLE
Causal attention

### DIFF
--- a/favor/favor.py
+++ b/favor/favor.py
@@ -118,7 +118,7 @@ class FAVOR(nn.Module):
                 phi_k.sum(dim=1)[..., None]  # (batch, r, 1)
             )
 
-        out /= norm
+        out = out / norm
 
         # restoring the desired shape
         out = out.permute(0, 2, 1)

--- a/favor/favor.py
+++ b/favor/favor.py
@@ -1,7 +1,6 @@
 import torch
 from torch import nn
 import torch.nn.functional as F
-from torch.cuda.amp import autocast
 from warnings import warn
 import itertools
 import math

--- a/favor/favor.py
+++ b/favor/favor.py
@@ -13,6 +13,7 @@ class FAVOR(nn.Module):
         self,
         key_dim,
         orthonormal=True,
+        multihead=True,
         causal=False,
         m=128,
         redraw=True,
@@ -24,6 +25,7 @@ class FAVOR(nn.Module):
         self.key_dim = key_dim
 
         self.orthonormal=orthonormal
+        self.multihead = multihead
         self.causal = causal
         self.redraw=redraw
         self.m = m
@@ -50,16 +52,21 @@ class FAVOR(nn.Module):
 
     def forward(self, keys, values, queries):
         """
-        keys: (batch, keys_dimension, *keys_locations)
-        values: (batch, values_dimension, *values_locations)
-        queries: (batch, keys_dimension, *queries_locations)
+        keys: (batch, heads, keys_dimension, *keys_locations)
+        values: (batch, heads, values_dimension, *keys_locations)
+        queries: (batch, heads, keys_dimension, *queries_locations)
+
+        If multihead is False, the heads dimension is to be omitted.
         """
+        if self.multihead:
+            # hiding the heads dimension in the batch dimension
+            num_heads = keys.shape[1]
+            keys, values, queries = (x.view(-1, *x.shape[2:]) for x in (keys, values, queries))
+
         # flattening everything
         keys_locations = keys.shape[2:]
         queries_locations = queries.shape[2:]
-        keys = keys.view(*keys.shape[:2], -1)
-        values = values.view(*values.shape[:2], -1)
-        queries = queries.view(*queries.shape[:2], -1)
+        keys, values, queries = (x.view(*x.shape[:2], -1) for x in (keys, values, queries))
 
         if self.causal and keys_locations != queries_locations:
             raise ValueError(
@@ -67,9 +74,7 @@ class FAVOR(nn.Module):
                 '{}, {}'.format(keys_locations, queries_locations))
 
         # getting to (batch, n, dim)
-        keys = keys.permute(0, 2, 1)
-        values = values.permute(0, 2, 1)
-        queries = queries.permute(0, 2, 1)
+        keys, values, queries = (x.permute(0, 2, 1) for x in (keys, values, queries))
 
         # features are (m, key_dim). randomized here if necessary
         features = self.features()
@@ -125,4 +130,6 @@ class FAVOR(nn.Module):
         # restoring the desired shape
         out = out.permute(0, 2, 1)
         out = out.reshape(*out.shape[:2], *queries_locations)
+        if self.multihead:
+            out = out.view(-1, num_heads, *out.shape[1:])
         return out

--- a/favor/favor.py
+++ b/favor/favor.py
@@ -4,7 +4,6 @@ import torch.nn.functional as F
 from torch.cuda.amp import autocast
 from warnings import warn
 import itertools
-import ipdb
 import math
 import numpy as np
 

--- a/favor/favor.py
+++ b/favor/favor.py
@@ -13,7 +13,6 @@ class FAVOR(nn.Module):
         self,
         key_dim,
         orthonormal=True,
-        multihead=True,
         causal=False,
         m=128,
         redraw=True,
@@ -25,7 +24,6 @@ class FAVOR(nn.Module):
         self.key_dim = key_dim
 
         self.orthonormal=orthonormal
-        self.multihead = multihead
         self.causal = causal
         self.redraw=redraw
         self.m = m
@@ -52,17 +50,10 @@ class FAVOR(nn.Module):
 
     def forward(self, keys, values, queries):
         """
-        keys: (batch, heads, keys_dimension, *keys_locations)
-        values: (batch, heads, values_dimension, *keys_locations)
-        queries: (batch, heads, keys_dimension, *queries_locations)
-
-        If multihead is False, the heads dimension is to be omitted.
+        keys: (batch, keys_dimension, *keys_locations)
+        values: (batch, values_dimension, *keys_locations)
+        queries: (batch, keys_dimension, *queries_locations)
         """
-        if self.multihead:
-            # hiding the heads dimension in the batch dimension
-            num_heads = keys.shape[1]
-            keys, values, queries = (x.view(-1, *x.shape[2:]) for x in (keys, values, queries))
-
         # flattening everything
         keys_locations = keys.shape[2:]
         queries_locations = queries.shape[2:]
@@ -130,6 +121,4 @@ class FAVOR(nn.Module):
         # restoring the desired shape
         out = out.permute(0, 2, 1)
         out = out.reshape(*out.shape[:2], *queries_locations)
-        if self.multihead:
-            out = out.view(-1, num_heads, *out.shape[1:])
         return out


### PR DESCRIPTION
Implementing causal ("unidirectional") attention. Seems to work:

```pycon
>>> att = FAVOR(16, redraw=False, multihead=False)
>>> k = torch.randn(1, 16, 10)
>>> q = torch.randn(1, 16, 10)
>>> v = torch.arange(1., 21.).view(1, 2, 10)
>>> v
tensor([[[ 1.,  2.,  3.,  4.,  5.,  6.,  7.,  8.,  9., 10.],
         [11., 12., 13., 14., 15., 16., 17., 18., 19., 20.]]])
>>> att(k, v, q)
tensor([[[ 5.4014,  5.4832,  5.3723,  5.6341,  5.9119,  5.5918,  5.7551,
           5.4221,  5.2524,  5.4419],
         [15.4014, 15.4832, 15.3723, 15.6341, 15.9119, 15.5918, 15.7551,
          15.4221, 15.2524, 15.4419]]])
>>> att.causal = True
>>> att(k, v, q)
tensor([[[ 1.0000,  1.5649,  1.9576,  2.4059,  2.8802,  3.1429,  3.5695,
           4.6532,  4.7577,  5.4419],
         [11.0000, 11.5649, 11.9576, 12.4059, 12.8802, 13.1429, 13.5695,
          14.6532, 14.7577, 15.4419]]])
```

Also implementing multi-head attention with `multihead=True`.